### PR TITLE
Add unslop — AI writing pattern remover

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - **[Readable.io](https://readable.io/):** Readable.io analyzes the readability of text and suggests ways to improve it.
 - **[Taskade](https://taskade.com/):** Taskade is a real-time collaborative editor for creating bullet lists, outlines, and task lists.
 - **[toprank](https://github.com/nowork-studio/toprank):** Open-source Claude Code plugin that includes an E-E-A-T focused content writer for SEO, keyword research with intent classification, and meta tag optimization. Pulls real Google Search Console data to drive recommendations, and pushes content changes directly to WordPress, Strapi, Contentful, or Ghost.
+- **[unslop](https://github.com/MohamedAbdallah-14/unslop):** Removes named AI writing patterns from text: tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocabulary. Lint-only audit mode and five intensity levels. Available as a CLI and MCP server.
 - **[Weallbehave](https://github.com/wealljs/weallbehave):** Weallbehave is a command-line tool for automatically generating and updating the `CODE_OF_CONDUCT.md` for your projects.
 - **[Write Good](https://github.com/btford/write-good):**  Write Good is a tool for improving language that can be run again code in a shell or within text editors via test editor plugins.
 


### PR DESCRIPTION
## Add unslop — AI writing pattern remover

**What is unslop?**

[unslop](https://github.com/MohamedAbdallah-14/unslop) is a CLI tool and MCP server that removes named AI writing patterns from text: tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocabulary like "delve" and "crucial".

**Why it fits this list**

The list already includes tools like Write Good (flags passive voice and weasel words) and Hemingway Editor (highlights style issues). Unslop addresses the same problem for a contemporary failure mode: text that reads as AI-generated because of specific repeating structural and vocabulary patterns.

**Details**
- Lint-only audit mode shows what would change without modifying the file
- Five intensity levels (1–5)
- Available as CLI and MCP server (Claude Code plugin)
- MIT licensed, public repository
- Works on any text: blog posts, documentation, commit messages, PRs

**Entry added**

```markdown
- **[unslop](https://github.com/MohamedAbdallah-14/unslop):** Removes named AI writing patterns from text: tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocabulary. Lint-only audit mode and five intensity levels. Available as a CLI and MCP server.
```

Inserted alphabetically between "toprank" and "Weallbehave".
