### PR TITLE
Add: Mangaplay Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - **[JigSaw](https://jigsaw.google.com/projects/):** A technology incubator focused on countering extremism and removing censorship online.
 - **[Kindling](https://kindlingwriter.com):** A free, open-source novel writing app that bridges outlining and drafting. Your outline's scene beats become expandable prompts inside a focused drafting space. Built with Rust and Tauri.
 - **[LanguageCheck](https://github.com/JohannesBuchner/languagecheck):** Analyses scientific papers written in LaTeX, offline or on overleaf. Analysis reports with suggestions for improvements include a list of common mistakes/ambiguities, tense consistency, a vs. an, spell check and paragraph topic sentences.
+- **[Mangaplay Studio](https://mangaplay.studio/):** A manga, comic and screenplay editor that uses a plain-text script format with visual panel layout and storyboard preview. Available as a web app and [Chrome extension](https://chromewebstore.google.com/detail/hiidpbendbgfcdidhccnldbkgdeikibi).
 - **[Markdownlint](https://github.com/markdownlint/markdownlint):** A tool to check markdown files and flag style issues.
   - **[Markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli):** Provides a command line interface for MarkdownLint.
 - **[Perspective API](https://www.perspectiveapi.com/#/):** An API that uses machine learning models to score the perceived impact of comments before they are sent. There is a demo nearer to the bottom of the page which can be used to try out the API.


### PR DESCRIPTION
Adding Mangaplay Studio -  a plain-text editor for writing manga, comic and screenplay scripts. It's available as a web app and Chrome extension for Google Docs.

