### PR TITLE
Add TinyTools AI Text Humanizer to writing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - **[Readable.io](https://readable.io/):** Readable.io analyzes the readability of text and suggests ways to improve it.
 - **[Taskade](https://taskade.com/):** Taskade is a real-time collaborative editor for creating bullet lists, outlines, and task lists.
 - **[toprank](https://github.com/nowork-studio/toprank):** Open-source Claude Code plugin that includes an E-E-A-T focused content writer for SEO, keyword research with intent classification, and meta tag optimization. Pulls real Google Search Console data to drive recommendations, and pushes content changes directly to WordPress, Strapi, Contentful, or Ghost.
+- **[TinyTools AI Text Humanizer](https://tinytools-smoky.vercel.app/ai-text-humanizer):** Free browser-based tool that rewrites AI-generated text to sound natural and human — no sign-up, runs entirely client-side.
 - **[Weallbehave](https://github.com/wealljs/weallbehave):** Weallbehave is a command-line tool for automatically generating and updating the `CODE_OF_CONDUCT.md` for your projects.
 - **[Write Good](https://github.com/btford/write-good):**  Write Good is a tool for improving language that can be run again code in a shell or within text editors via test editor plugins.
 


### PR DESCRIPTION
## Add TinyTools AI Text Humanizer

Adding **[TinyTools AI Text Humanizer](https://tinytools-smoky.vercel.app/ai-text-humanizer)** to the list.

**Why it fits:** It's a free browser-based tool that rewrites AI-generated text to sound natural and human — no sign-up required, runs entirely client-side, open source.

The project also includes other writing-adjacent utilities like an AI Text Roast, AI Prompt Enhancer, and Cover Letter Generator at [tinytools-smoky.vercel.app](https://tinytools-smoky.vercel.app/).

Alphabetical insertion between *toprank* and *Weallbehave*.