### PR TITLE
Add slop-gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - **[Perspective API](https://www.perspectiveapi.com/#/):** An API that uses machine learning models to score the perceived impact of comments before they are sent. There is a demo nearer to the bottom of the page which can be used to try out the API.
 - **[ProWritingAid](https://prowritingaid.com/):** ProWritingAid suggests edits for repetitiveness, vague wording, sentence length variation, over-dependence on adverbs, passive voice, over-complicated sentence constructions, spelling, and grammar.
 - **[Readable.io](https://readable.io/):** Readable.io analyzes the readability of text and suggests ways to improve it.
+- **[slop-gate](https://github.com/hwajongpark/slop-gate):** Zero-dependency CLI that catches AI writing-tells before they ship: the em-dash and filler words in English, plus translationese in Korean, Russian, Vietnamese, Chinese, and Filipino. Runs locally or in CI.
 - **[Taskade](https://taskade.com/):** Taskade is a real-time collaborative editor for creating bullet lists, outlines, and task lists.
 - **[toprank](https://github.com/nowork-studio/toprank):** Open-source Claude Code plugin that includes an E-E-A-T focused content writer for SEO, keyword research with intent classification, and meta tag optimization. Pulls real Google Search Console data to drive recommendations, and pushes content changes directly to WordPress, Strapi, Contentful, or Ghost.
 - **[Weallbehave](https://github.com/wealljs/weallbehave):** Weallbehave is a command-line tool for automatically generating and updating the `CODE_OF_CONDUCT.md` for your projects.


### PR DESCRIPTION
Adds [slop-gate](https://github.com/hwajongpark/slop-gate), inserted alphabetically.

A zero-dependency CLI prose linter in the same family as Alex.js, Proselint, and Vale (already on the list). It flags AI writing-tells before they ship: the em-dash and ~40 filler words in English, plus opt-in translationese packs for Korean, Russian, Vietnamese, Chinese, and Filipino. Runs locally or in CI. MIT licensed.

Format matches the list convention: `- **[Name](url):** Description.`