### PR TITLE
Add slopless

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - **[Perspective API](https://www.perspectiveapi.com/#/):** An API that uses machine learning models to score the perceived impact of comments before they are sent. There is a demo nearer to the bottom of the page which can be used to try out the API.
 - **[ProWritingAid](https://prowritingaid.com/):** ProWritingAid suggests edits for repetitiveness, vague wording, sentence length variation, over-dependence on adverbs, passive voice, over-complicated sentence constructions, spelling, and grammar.
 - **[Readable.io](https://readable.io/):** Readable.io analyzes the readability of text and suggests ways to improve it.
+- **[slopless](https://github.com/seochecks-ai/slopless):** Give it to your writing agent and it stops handing you AI-slop prose: a deterministic textlint preset and CLI that flags the LLM tells without calling an LLM.
 - **[Taskade](https://taskade.com/):** Taskade is a real-time collaborative editor for creating bullet lists, outlines, and task lists.
 - **[toprank](https://github.com/nowork-studio/toprank):** Open-source Claude Code plugin that includes an E-E-A-T focused content writer for SEO, keyword research with intent classification, and meta tag optimization. Pulls real Google Search Console data to drive recommendations, and pushes content changes directly to WordPress, Strapi, Contentful, or Ghost.
 - **[Weallbehave](https://github.com/wealljs/weallbehave):** Weallbehave is a command-line tool for automatically generating and updating the `CODE_OF_CONDUCT.md` for your projects.


### PR DESCRIPTION
Adds slopless, a deterministic textlint preset and CLI that flags AI-generated and padded English-Markdown prose (hollow framing, fake "not X but Y" contrasts, hedging, em-dash overuse, vacuous closers, and similar LLM tells) without calling an LLM, so it runs reproducibly in CI and emits JSON findings. It fits this list as a writing-quality linter alongside Alex.js, Write Good, and Markdownlint. Repo: https://github.com/seochecks-ai/slopless | npm: https://www.npmjs.com/package/slopless