### PR TITLE
feat: add NotFair — SEO and paid-ads Claude Code skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - **[LanguageCheck](https://github.com/JohannesBuchner/languagecheck):** Analyses scientific papers written in LaTeX, offline or on overleaf. Analysis reports with suggestions for improvements include a list of common mistakes/ambiguities, tense consistency, a vs. an, spell check and paragraph topic sentences.
 - **[Markdownlint](https://github.com/markdownlint/markdownlint):** A tool to check markdown files and flag style issues.
   - **[Markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli):** Provides a command line interface for MarkdownLint.
+- **[NotFair](https://github.com/nowork-studio/NotFair):** Open-source Claude Code skills for SEO content, keyword research, and paid ads. Connects to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP to drive real recommendations.
 - **[Perspective API](https://www.perspectiveapi.com/#/):** An API that uses machine learning models to score the perceived impact of comments before they are sent. There is a demo nearer to the bottom of the page which can be used to try out the API.
 - **[ProWritingAid](https://prowritingaid.com/):** ProWritingAid suggests edits for repetitiveness, vague wording, sentence length variation, over-dependence on adverbs, passive voice, over-complicated sentence constructions, spelling, and grammar.
 - **[Readable.io](https://readable.io/):** Readable.io analyzes the readability of text and suggests ways to improve it.


### PR DESCRIPTION
Thanks for maintaining this list — it's a solid collection.

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)**, an open-source set of Claude Code agent skills for SEO content writing, keyword research, Google Ads, and Meta Ads work. It has ~2.9k stars and connects to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP to power its recommendations.

It fits here alongside the other AI writing and content tools — particularly for SEO content workflows. I placed it alphabetically under **N**, matching the existing list format.

Happy to reword, move, or trim the entry if anything doesn't quite fit. Thanks again!