### PR TITLE
Add Show Me My Book (alphabetical order)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - **[Perspective API](https://www.perspectiveapi.com/#/):** An API that uses machine learning models to score the perceived impact of comments before they are sent. There is a demo nearer to the bottom of the page which can be used to try out the API.
 - **[ProWritingAid](https://prowritingaid.com/):** ProWritingAid suggests edits for repetitiveness, vague wording, sentence length variation, over-dependence on adverbs, passive voice, over-complicated sentence constructions, spelling, and grammar.
 - **[Readable.io](https://readable.io/):** Readable.io analyzes the readability of text and suggests ways to improve it.
+- **[Show Me My Book](https://showmemybook.com):** A canon bible for novelists: every character, place, moment and thread, cross-linked and cited to the page it came from.
 - **[Taskade](https://taskade.com/):** Taskade is a real-time collaborative editor for creating bullet lists, outlines, and task lists.
 - **[toprank](https://github.com/nowork-studio/toprank):** Open-source Claude Code plugin that includes an E-E-A-T focused content writer for SEO, keyword research with intent classification, and meta tag optimization. Pulls real Google Search Console data to drive recommendations, and pushes content changes directly to WordPress, Strapi, Contentful, or Ghost.
 - **[Weallbehave](https://github.com/wealljs/weallbehave):** Weallbehave is a command-line tool for automatically generating and updating the `CODE_OF_CONDUCT.md` for your projects.


### PR DESCRIPTION
Adds Show Me My Book (https://showmemybook.com) to the list in alphabetical order, between Readable.io and Taskade.

Show Me My Book is a canon bible service for novelists: it reads a finished manuscript and returns every character, place, moment and story thread, cross-linked and cited to the page each appears on. Nothing is invented or written for the author. It fits alongside other novel-writing tools already on this list (Chisel Editor, Kindling) as a tool aimed at the drafting and revision phase.

Disclosure: I built this. It is my product. I am submitting it because I believe it is a genuine resource for novelists and fits the spirit of this list. The maintainer should of course apply the usual quality bar.