### PR TITLE
Update CiteMe entry (discontinued integrations removed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - **[Atomic AI / Atomic Reach](https://www.atomicreach.com/):** Real time, custom and predictive recommendations to create well written content with your audience in mind every time.
 - **[The Chicago Manual of Style](http://www.chicagomanualofstyle.org/home.html):** The Chicago Manual of Style Online is the venerable, time-tested guide to style, usage, and grammar in an accessible online format.
 - **[Chisel Editor](https://egonschiele.github.io/chisel-docs/):**  An AI-powered tool for writing books and stories.
-- **[CiteMe](https://citeme.app/):** AI-powered academic citation generator that searches 8+ databases and formats references in 40+ styles (APA, MLA, Chicago, ABNT, etc.). Includes browser extensions and Word/Google Docs integrations.
+- **[CiteMe](https://citeme.app/):** Free academic citation generator with a built-in reference checker that flags fabricated or hallucinated references — searches 8+ databases and formats references in 40+ styles (APA, MLA, Chicago, ABNT, etc.). No sign-up; available in English, Spanish, Portuguese, French, and German.
 - **[Cliche Finder](http://cliche.theinfo.org/):** Finds and highlights cliches in your writing.
 - **[Contributor Covenant](https://www.contributor-covenant.org/):** A code of conduct pledge, to respect and appreciate contributors and participants in open source projects.
 - **[Danger](https://github.com/danger/danger):** Formalizes pull request ettiquette.


### PR DESCRIPTION
Update to the existing **CiteMe** entry:

- Removes the Word / Google Docs integrations, which have been **discontinued** — the current line is no longer accurate.
- Leads with CiteMe's **reference checker** (flags fabricated / hallucinated references) and notes the 5-language interface.
- Drops the "AI-powered" phrasing for a neutral description.

Disclosure: I maintain CiteMe. Thanks for the list!