### PR TITLE
Add Words to Pages to writing tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - **[Taskade](https://taskade.com/):** Taskade is a real-time collaborative editor for creating bullet lists, outlines, and task lists.
 - **[toprank](https://github.com/nowork-studio/toprank):** Open-source Claude Code plugin that includes an E-E-A-T focused content writer for SEO, keyword research with intent classification, and meta tag optimization. Pulls real Google Search Console data to drive recommendations, and pushes content changes directly to WordPress, Strapi, Contentful, or Ghost.
 - **[Weallbehave](https://github.com/wealljs/weallbehave):** Weallbehave is a command-line tool for automatically generating and updating the `CODE_OF_CONDUCT.md` for your projects.
+- **[Words to Pages](https://nutilz.com/words-to-pages):** Free calculator that converts word count to page count instantly. Choose font, size, spacing, and margins to see exact page counts for academic, professional, and manuscript formats.
 - **[Write Good](https://github.com/btford/write-good):**  Write Good is a tool for improving language that can be run again code in a shell or within text editors via test editor plugins.
 
 ---


### PR DESCRIPTION
Adds [Words to Pages](https://nutilz.com/words-to-pages), a free calculator that converts word count to page count. Lets you set font, size, spacing, and margins to get exact page counts for academic, professional, and manuscript formats — useful for anyone hitting a word- or page-count target. No signup required.

Added alphabetically between Weallbehave and Write Good to match the list format.