### PR TITLE
Add Write Wall

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - **[toprank](https://github.com/nowork-studio/toprank):** Open-source Claude Code plugin that includes an E-E-A-T focused content writer for SEO, keyword research with intent classification, and meta tag optimization. Pulls real Google Search Console data to drive recommendations, and pushes content changes directly to WordPress, Strapi, Contentful, or Ghost.
 - **[Weallbehave](https://github.com/wealljs/weallbehave):** Weallbehave is a command-line tool for automatically generating and updating the `CODE_OF_CONDUCT.md` for your projects.
 - **[Write Good](https://github.com/btford/write-good):**  Write Good is a tool for improving language that can be run again code in a shell or within text editors via test editor plugins.
+- **[Write Wall](https://github.com/gcko/Write-Wall):** A free, open-source Chrome extension for distraction-free markdown writing, with focus and typewriter modes. Notes follow you across machines through the signed-in Chrome account, with no server of its own and no telemetry.
 
 ---
 


### PR DESCRIPTION
Adding Write Wall, a Chrome extension I maintain: a distraction-free markdown pad with focus and typewriter modes, in the same spirit as Inkwell and Kindling already on the list. It syncs notes through the signed-in Chrome account rather than running its own backend, collects nothing, and is CC BY-SA 4.0 on GitHub. Entry added in alphabetical order after Write Good, matching the existing format.