### PR TITLE
Add Notula

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - **[LanguageCheck](https://github.com/JohannesBuchner/languagecheck):** Analyses scientific papers written in LaTeX, offline or on overleaf. Analysis reports with suggestions for improvements include a list of common mistakes/ambiguities, tense consistency, a vs. an, spell check and paragraph topic sentences.
 - **[Markdownlint](https://github.com/markdownlint/markdownlint):** A tool to check markdown files and flag style issues.
   - **[Markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli):** Provides a command line interface for MarkdownLint.
+- **[Notula](https://notula.org):** A desktop editor for the Markdown that already lives in a git repository. WYSIWYG with no syntax on screen, and comment threads are committed beside the documents, so a reviewer can leave feedback on a document without opening a pull request. Free, macOS and Windows.
 - **[Perspective API](https://www.perspectiveapi.com/#/):** An API that uses machine learning models to score the perceived impact of comments before they are sent. There is a demo nearer to the bottom of the page which can be used to try out the API.
 - **[ProWritingAid](https://prowritingaid.com/):** ProWritingAid suggests edits for repetitiveness, vague wording, sentence length variation, over-dependence on adverbs, passive voice, over-complicated sentence constructions, spelling, and grammar.
 - **[Readable.io](https://readable.io/):** Readable.io analyzes the readability of text and suggests ways to improve it.


### PR DESCRIPTION
Adds **Notula**, kept in alphabetical order between Markdownlint and Perspective API.

Notula is a free desktop editor for the Markdown that already lives in a git repository. It is aimed at the part of writing this list is about - getting a document read and improved by someone else: select a passage, leave a comment, reply, resolve, and the threads are committed next to the document as plain files rather than held in a service. That lets a subject matter expert review a doc without learning git or opening a pull request, and the document itself stays ordinary Markdown.

Free, no account and no server, macOS and Windows.