### PR TITLE
Add IELTS Writing Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - **[Danger](https://github.com/danger/danger):** Formalizes pull request ettiquette.
 - **[Grammarly](https://www.grammarly.com/):** Grammarly makes sure everything you type is clear and mistake-free. It even checks for plagiarism.
 - **[The Hemingway Editor](http://www.hemingwayapp.com/):** Hemingway helps you write with power and clarity by highlighting adverbs, passive voice, and dull, complicated words. Cut the dead weight from your writing.
+- **[IELTS Writing Checker](https://ieltswritingchecker.org/):** Reviews IELTS Academic Task 1, General Training Task 1, and Task 2 writing with criterion-specific feedback and revision guidance.
 - **[Inkwell](https://github.com/4worlds4w-svg/inkwell):** A lightweight Markdown editor built with Rust and Tauri. Split view, live preview, 4 themes, focus mode, typewriter mode, and version history. No cloud, no accounts, no telemetry.
 - **[JigSaw](https://jigsaw.google.com/projects/):** A technology incubator focused on countering extremism and removing censorship online.
 - **[Kindling](https://kindlingwriter.com):** A free, open-source novel writing app that bridges outlining and drafting. Your outline's scene beats become expandable prompts inside a focused drafting space. Built with Rust and Tauri.


### PR DESCRIPTION
## Summary

Add IELTS Writing Checker to the alphabetized writing-tool list.

## Why

It provides writing-specific review for IELTS Academic Task 1, General Training Task 1, and Task 2, including criterion-specific feedback and revision guidance.

Disclosure: I maintain IELTS Writing Checker.

## Validation

- confirmed the website returns HTTP 200
- ran `git diff --check`
- confirmed the URL is not already present in this repository
