### PR TITLE
chore: cleans up oss items that ended up just being businesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@
 ---
 
 - **[Alex.js](http://alexjs.com/):** Catch insensitive, inconsiderate writing. Whether your own or someone else’s writing, Alex helps you find gender favoring, polarizing, race related, religion inconsiderate, or another unequal phrasing.
-- **[Atomic AI / Atomic Reach](https://www.atomicreach.com/):** Real time, custom and predictive recommendations to create well written content with your audience in mind every time.
 - **[The Chicago Manual of Style](http://www.chicagomanualofstyle.org/home.html):** The Chicago Manual of Style Online is the venerable, time-tested guide to style, usage, and grammar in an accessible online format.
 - **[Chisel Editor](https://egonschiele.github.io/chisel-docs/):**  An AI-powered tool for writing books and stories.
-- **[CiteMe](https://citeme.app/):** AI-powered academic citation generator that searches 8+ databases and formats references in 40+ styles (APA, MLA, Chicago, ABNT, etc.). Includes browser extensions and Word/Google Docs integrations.
 - **[Cliche Finder](http://cliche.theinfo.org/):** Finds and highlights cliches in your writing.
 - **[Contributor Covenant](https://www.contributor-covenant.org/):** A code of conduct pledge, to respect and appreciate contributors and participants in open source projects.
 - **[Danger](https://github.com/danger/danger):** Formalizes pull request ettiquette.
@@ -20,9 +18,6 @@
 - **[Markdownlint](https://github.com/markdownlint/markdownlint):** A tool to check markdown files and flag style issues.
   - **[Markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli):** Provides a command line interface for MarkdownLint.
 - **[Perspective API](https://www.perspectiveapi.com/#/):** An API that uses machine learning models to score the perceived impact of comments before they are sent. There is a demo nearer to the bottom of the page which can be used to try out the API.
-- **[ProWritingAid](https://prowritingaid.com/):** ProWritingAid suggests edits for repetitiveness, vague wording, sentence length variation, over-dependence on adverbs, passive voice, over-complicated sentence constructions, spelling, and grammar.
-- **[Readable.io](https://readable.io/):** Readable.io analyzes the readability of text and suggests ways to improve it.
-- **[Taskade](https://taskade.com/):** Taskade is a real-time collaborative editor for creating bullet lists, outlines, and task lists.
 - **[toprank](https://github.com/nowork-studio/toprank):** Open-source Claude Code plugin that includes an E-E-A-T focused content writer for SEO, keyword research with intent classification, and meta tag optimization. Pulls real Google Search Console data to drive recommendations, and pushes content changes directly to WordPress, Strapi, Contentful, or Ghost.
 - **[Weallbehave](https://github.com/wealljs/weallbehave):** Weallbehave is a command-line tool for automatically generating and updating the `CODE_OF_CONDUCT.md` for your projects.
 - **[Write Good](https://github.com/btford/write-good):**  Write Good is a tool for improving language that can be run again code in a shell or within text editors via test editor plugins.


### PR DESCRIPTION
## Description

This PR removes links to businesses that appear to now mainly be business focused.

### Related 

Very interesting prs. I'm lucky to have insight into this project. 
1. Many businesses around using AI to do less: write less, research less, and have AI do the citing.
2. Many businesses around removing AI texts, and validating the AI text and research. 

<img width="699" height="904" alt="SCR-20260815-lbmb" src="https://github.com/user-attachments/assets/58a84243-5447-4058-9178-8739a6e723cc" />
