### PR TITLE
Add 1667

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 ---
 
+- **[1667](https://github.com/1667-ai/1667):** A full-screen terminal environment for writing fiction with language models. Each story part can hold alternative takes in a tree, and you select one story line to read or export. Works with local model servers (Ollama, llama.cpp, KoboldCpp, LM Studio) and with OpenAI-compatible or Anthropic endpoints. Stories stay in a local project folder. Apache 2.0, for macOS, Linux, and Windows.
 - **[Alex.js](http://alexjs.com/):** Catch insensitive, inconsiderate writing. Whether your own or someone else’s writing, Alex helps you find gender favoring, polarizing, race related, religion inconsiderate, or another unequal phrasing.
 - **[The Chicago Manual of Style](http://www.chicagomanualofstyle.org/home.html):** The Chicago Manual of Style Online is the venerable, time-tested guide to style, usage, and grammar in an accessible online format.
 - **[Chisel Editor](https://egonschiele.github.io/chisel-docs/):**  An AI-powered tool for writing books and stories.


### PR DESCRIPTION
Adds 1667 to the list. I am the developer.

1667 is a terminal environment for writing fiction with language models. A story part can hold several alternative takes. The takes stay in a tree, and the writer selects one story line to read or export. Export writes Markdown to the project folder.

It connects to local model servers (Ollama, llama.cpp, KoboldCpp, LM Studio) and to OpenAI-compatible or Anthropic endpoints. Stories and settings stay in a local project folder.

Apache 2.0. Installers for macOS, Linux, and Windows x64.

The entry keeps the alphabetical order of the list and the existing `- **[Name](url):** Description.` format.